### PR TITLE
Fix: Fetch git tags with a semantic order.

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -1086,10 +1086,9 @@ async function run() {
 
         let tags = [];
         try {
-            tags = (await cmd('git', `tag` ))
+            tags = (await cmd('git', `tag`, '--sort', '-v:refname' ))
                 .trim()
-                .split(eol)
-                .reverse();
+                .split(eol);
             if (tags.length === 1 && tags[0] === "") {
                 tags = [];
             }


### PR DESCRIPTION
With `--sort v:refname`:

```
v0.2.1dev1
v0.3.0dev4
...
v0.3.0dev8
v0.3.0dev9
v0.3.0dev10
```

Without it (note the position of `v0.3.0dev10`):

```
v0.2.1dev1
v0.3.0dev10
v0.3.0dev4
...
v0.3.0dev8
v0.3.0dev9
```

Trailing `-` of `-v:refname` reverses the order, so that the highest value comes first.